### PR TITLE
HOCS-1491

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -37,7 +37,14 @@ fi
 
 cd kd
 
-kd --insecure-skip-tls-verify \
-   --timeout 10m \
-    -f deployment.yaml \
-    -f service.yaml
+if [[ ${KUBE_NAMESPACE} == "wcs-prod" ]] ; then
+    kd --insecure-skip-tls-verify \
+       --timeout 10m \
+        -f deployment-wcs-prod.yaml \
+        -f service.yaml
+else
+    kd --insecure-skip-tls-verify \
+       --timeout 10m \
+        -f deployment.yaml \
+        -f service.yaml
+fi

--- a/kd/deployment-wcs-prod.yaml
+++ b/kd/deployment-wcs-prod.yaml
@@ -1,0 +1,363 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hocs-docs
+  labels:
+    version: {{.VERSION}}
+spec:
+  replicas: {{.REPLICAS}}
+  selector:
+    matchLabels:
+      name: hocs-docs
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: hocs-docs
+        role: hocs-backend
+        version: {{.VERSION}}
+    spec:
+      imagePullSecrets:
+        - name: registry-credentials
+      initContainers:
+        - name: truststore
+          image: quay.io/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.6
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          args:
+            - --certs=/certs
+            - --command=/usr/bin/create-keystore.sh /certs/tls.pem /certs/tls-key.pem /etc/ssl/certs/acp-root.crt
+            - --domain=hocs-docs.${KUBE_NAMESPACE}.svc.cluster.local
+            - --domain=localhost
+            - --onetime=true
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+            - name: keystore
+              mountPath: /etc/keystore
+            - name: bundle
+              mountPath: /etc/ssl/certs
+              readOnly: true
+        - name: db-initialise
+          image: docker.digital.homeoffice.gov.uk/hocs-db-provision:latest
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          env:
+            - name: DB_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: endpoint
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: db_name
+            - name: ROOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: password
+            - name: DB_SCHEMA_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_schema
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_password
+            - name: DB_READONLY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-db-readonly
+                  key: rds_user
+            - name: DB_READONLY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-db-readonly
+                  key: rds_password
+      containers:
+        - name: certs
+          image: quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.6
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          args:
+            - --certs=/certs
+            - --domain=hocs-docs.${KUBE_NAMESPACE}.svc.cluster.local
+            - --expiry=8760h
+            - --command=/usr/local/scripts/trigger_nginx_reload.sh
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+            - name: bundle
+              mountPath: /etc/ssl/certs
+              readOnly: true
+
+        - name: proxy
+          image: quay.io/ukhomeofficedigital/nginx-proxy:v3.4.12
+          imagePullPolicy: Always
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 250m
+            requests:
+              memory: 256Mi
+              cpu: 150m
+          env:
+            - name: PROXY_SERVICE_HOST
+              value: '127.0.0.1'
+            - name: PROXY_SERVICE_PORT
+              value: '8080'
+            - name: NAXSI_USE_DEFAULT_RULES
+              value: 'FALSE'
+            - name: ENABLE_UUID_PARAM
+              value: 'FALSE'
+            - name: HTTPS_REDIRECT
+              value: 'FALSE'
+            - name: BASIC_AUTH
+              value: /etc/nginx/authsecrets/htpasswd
+            - name: SERVER_CERT
+              value: /certs/tls.pem
+            - name: SERVER_KEY
+              value: /certs/tls-key.pem
+            - name: ADD_NGINX_SERVER_CFG
+              value: 'location = /reload { allow 127.0.0.1; deny all; content_by_lua_block { os.execute("touch /tmp/nginx-reload-triggered; /usr/local/openresty/nginx/sbin/nginx -s reload; touch /tmp/nginx-reload-complete;") } }'
+            - name: CLIENT_MAX_BODY_SIZE
+              value: '52'
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/nginx/secrets
+              readOnly: true
+            - name: auth-secrets
+              mountPath: /etc/nginx/authsecrets
+              readOnly: true
+          ports:
+            - name: https
+              containerPort: 10443
+        - name: hocs-docs
+          image: quay.io/ukhomeofficedigital/hocs-docs:{{.VERSION}}
+          imagePullPolicy: Always
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          envFrom:
+            - configMapRef:
+                name: hocs-queue-config
+          env:
+            - name: JAVA_OPTS
+              value: '-Xms384m -Xmx2772m -XX:+UseG1GC -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.svc.cluster.local'
+            - name: JDK_TRUST_FILE
+              value: '/etc/keystore/truststore.jks'
+            - name: SERVER_PORT
+              value: '8080'
+            - name: ENDPOINTS_INFO_ENABLED
+              value: 'false'
+            - name: SPRING_PROFILES_ACTIVE
+              value: 'sqs, sns, s3, postgres'
+            - name: CLAMAV_ROOT
+              value: 'https4://clamav.virus-scan.svc.cluster.local'
+            - name: HOCSCONVERTER_ROOT
+              value: 'https4://hocs-docs-converter.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: endpoint
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: port
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: db_name
+            - name: DB_SCHEMA_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_schema
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_password
+            - name: DOCS_QUEUE_NAME
+              value:
+                '{{.KUBE_NAMESPACE}}-document-sqs'
+            - name: DOCS_QUEUE_DLQ_NAME
+              value:
+                '{{.KUBE_NAMESPACE}}-document-sqs-dlq'
+            - name: DOCS_AWS_SQS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: '{{.KUBE_NAMESPACE}}-document-sqs'
+                  key: access_key_id
+            - name: DOCS_AWS_SQS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: '{{.KUBE_NAMESPACE}}-document-sqs'
+                  key: secret_access_key
+            - name: DOCS_TRUSTEDS3BUCKETNAME
+              value:
+                '{{.KUBE_NAMESPACE}}-trusted-s3'
+            - name: DOCS_UNTRUSTEDS3BUCKETNAME
+              value:
+                '{{.KUBE_NAMESPACE}}-untrusted-s3'
+            - name: DOCS_AWS_SQS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-document-sqs
+                  key: access_key_id
+            - name: DOCS_AWS_SQS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-document-sqs
+                  key: secret_access_key
+            - name: TRUSTED_AWS_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-trusted-s3
+                  key: access_key_id
+            - name: TRUSTED_AWS_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-trusted-s3
+                  key: secret_access_key
+            - name: DOCS_TRUSTEDS3BUCKETKMSKEYID
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-trusted-s3
+                  key: kms_key_id
+            - name: UNTRUSTED_AWS_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-untrusted-s3
+                  key: access_key_id
+            - name: UNTRUSTED_AWS_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-untrusted-s3
+                  key: secret_access_key
+            - name: AUDIT_TOPIC_NAME
+              value: {{.KUBE_NAMESPACE}}-sns
+            - name: AUDIT_AWS_SNS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-audit-sqs
+                  key: access_key_id
+            - name: AUDIT_AWS_SNS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-audit-sqs
+                  key: secret_access_key
+            - name: AUDITING_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: AUDITING_DEPLOYMENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            limits:
+              cpu: 850m
+              memory: 3072Mi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+              httpHeaders:
+                - name: X-probe
+                  value: kubelet
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+              httpHeaders:
+                - name: X-probe
+                  value: kubelet
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 10
+          volumeMounts:
+            - mountPath: /etc/keystore
+              name: keystore
+              readOnly: true
+      volumes:
+        - name: keystore
+          emptyDir:
+            medium: "Memory"
+        - name: certs
+          emptyDir:
+            medium: "Memory"
+        - name: bundle
+          configMap:
+            name: bundle
+        - name: secrets
+          emptyDir:
+            medium: "Memory"
+        - name: auth-secrets
+          secret:
+            secretName: ui-casework-creds


### PR DESCRIPTION
Modified the trusted and untrusted bucket names for wcs-prod.
Not-prod environment has single trusted and untrusted buckets for both CS and WCS to share, so they scripts use a static 'cs-' with the environment. This does not work in WCS PROD.